### PR TITLE
Changing VacuumDevice to VacuumEntity

### DIFF
--- a/custom_components/automower/__init__.py
+++ b/custom_components/automower/__init__.py
@@ -11,10 +11,16 @@ import voluptuous as vol
 
 from datetime import datetime
 from homeassistant.const import CONF_ICON, CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
-from homeassistant.components.vacuum import (
+try:
+    from homeassistant.components.vacuum import (
     SUPPORT_BATTERY, SUPPORT_PAUSE, SUPPORT_RETURN_HOME,
     SUPPORT_STATUS, SUPPORT_STOP, SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON, VacuumDevice)
+    SUPPORT_TURN_ON, VacuumEntity)
+except ImportError:
+    from homeassistant.components.vacuum import (
+    SUPPORT_BATTERY, SUPPORT_PAUSE, SUPPORT_RETURN_HOME,
+    SUPPORT_STATUS, SUPPORT_STOP, SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON, VacuumDevice as VacuumEntity)
 
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
@@ -130,7 +136,7 @@ def setup(hass, base_config):
     return True
 
 
-class AutomowerDevice(VacuumDevice):
+class AutomowerDevice(VacuumEntity):
     """Representation of an Automower device."""
 
     def __init__(self, meta, api):


### PR DESCRIPTION
adjusting for the change in 110 and 111 as the VacuumDevice was renamed to VacuumEntity

changes made based on https://developers.home-assistant.io/blog/2020/05/14/entity-class-names/

Limited testing done on 0.110 . The depreciation message is gone. Have not tested pre 110 versions.