### PR TITLE
Fixes automower in 2021.9

### DIFF
--- a/custom_components/automower/__init__.py
+++ b/custom_components/automower/__init__.py
@@ -236,7 +236,8 @@ class AutomowerDevice(VacuumEntity):
         _LOGGER.debug("Initializing device: %s", meta['name'])
         self._id = meta['id']
         self._name = meta['name']
-        self._model = meta['model']
+        """Husqvarna API stoppped returning model number, HA prior to 2021.9 defaulted to none."""
+        self._model = None
         self._state = None
         self._mower_status = None
         self._stored_timestamp = None

--- a/custom_components/automower/manifest.json
+++ b/custom_components/automower/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/walthowd/ha-automower/",
   "dependencies": [],
   "codeowners": ["@walthowd"],
-  "version": "1.1.2",
+  "version": "1.1.3",
   "requirements": ["pyhusmow==0.1.1"]
 }


### PR DESCRIPTION
Husqvarna API stopped returning model some time back. Previously HA would set the default to 'none' but that broke with KeyError in 2021.9