### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/automower/__init__.py
+++ b/custom_components/automower/__init__.py
@@ -30,7 +30,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_ICON = 'mdi:robot-mower'
 DOMAIN = 'automower'
-REQUIREMENTS = ['pyhusmow==0.1.1']
 VENDOR = 'Husqvarna'
 
 # TODO: Add more statuses as we observe them

--- a/custom_components/automower/manifest.json
+++ b/custom_components/automower/manifest.json
@@ -5,5 +5,5 @@
   "dependencies": [],
   "codeowners": ["@walthowd"],
   "version": "1.1.3",
-  "requirements": ["pyhusmow==0.1.1"]
+  "requirements": ["pyhusmow @ git+https://github.com/MAFLO321/pyhusmow.git@v0.3.0"]
 }


### PR DESCRIPTION
Fix the api after it got broken because Husqvarna removed the obsolete
one. The original repo of pyhusmow is archived, therefore it was
necessary to fork it. Just use the fork for now.

Fixes #26